### PR TITLE
bugfix parse data-originalsrc

### DIFF
--- a/lib/postmortem/layout.rb
+++ b/lib/postmortem/layout.rb
@@ -54,13 +54,23 @@ module Postmortem
     def with_inlined_images(body)
       parsed = Nokogiri::HTML.parse(body)
       parsed.css('img').each do |img|
-        uri = try_uri(img['src'])
+        uri = extract_image_uri(img)
         next unless local_file?(uri)
 
         path = located_image(uri)
         img['src'] = encoded_image(path) unless path.nil?
       end
       parsed.to_s
+    end
+
+    def extract_image_uri(img)
+      src_uri = try_uri(img['src'])
+      return src_uri if src_uri&.path.present?
+
+      original_src_uri = try_uri(img['data-originalsrc'])
+      return original_src_uri if original_src_uri&.path.present?
+
+      nil
     end
 
     def local_file?(uri)

--- a/lib/postmortem/version.rb
+++ b/lib/postmortem/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Postmortem
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
Actions:

+ parse data-originalsrc in addition to src.

Motivation:

+ When parsing URI that uses the cid scheme, it results in a URI::Generic object because Ruby's URI library does not provide specific handling for cid URIs by default. uri.path was nil hence breaking, in this case parsing an additional "data-originalsrc" attibute resulted in correct result.